### PR TITLE
Update dependencies and bump to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ readme = "README.md"
 
 [dependencies]
 sample-consensus = "1.0.1"
-rand_core = "0.5.1"
 libm = "0.2.1"
+rand_core = "0.6.1"
 
 [dev-dependencies]
-nalgebra = "0.21.1"
-rand_pcg = "0.2.1"
-rand = "0.7.3"
+nalgebra = "0.24.0"
+rand_pcg = "0.3.0"
+rand = "0.8.1"
 
 [profile.dev]
 opt-level = 3

--- a/tests/lines.rs
+++ b/tests/lines.rs
@@ -45,14 +45,14 @@ fn lines() {
 
     for _ in 0..2000 {
         // Generate <a, b> and normalize.
-        let norm = Vector2::new(rng.gen_range(-10.0, 10.0), rng.gen_range(-10.0, 10.0)).normalize();
+        let norm = Vector2::new(rng.gen_range(-10.0..10.0), rng.gen_range(-10.0..10.0)).normalize();
         // Get parallel ray.
         let ray = Vector2::new(norm.y, -norm.x);
         // Generate random c.
-        let c = rng.gen_range(-10.0, 10.0);
+        let c = rng.gen_range(-10.0..10.0);
 
         // Generate random number of points between 50 and 1000.
-        let num = rng.gen_range(100, 1000);
+        let num = rng.gen_range(100..1000);
         // The points should be no more than 5.0 away from the line and be evenly distributed away from the line.
         let residuals = Uniform::new(-5.0, 5.0);
         // The points must be generated along the line, but the distance should be bounded to make it more difficult.


### PR DESCRIPTION
This PR selects the dep versions.
- nalgebra 0.24
- rand 0.8
- rand_core 0.6
- rand_pcg 0.3

The `Cargo.toml` is changed to specify versions down to "minor" version.
Due to SemVer, "patch" version does not introduce breaking change, I think specifying patch version is not necessary.