### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ readme = "README.md"
 [dependencies]
 sample-consensus = "1.0.1"
 libm = "0.2.1"
-rand_core = "0.6.2"
+rand_core = "0.6.3"
 
 [dev-dependencies]
 nalgebra = "0.25.3"
-rand_pcg = "0.3.0"
-rand = "0.8.3"
+rand_pcg = "0.3.1"
+rand = "0.8.4"
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libm = "0.2.1"
 rand_core = "0.6.3"
 
 [dev-dependencies]
-nalgebra = "0.25.3"
+nalgebra = "0.27.1"
 rand_pcg = "0.3.1"
 rand = "0.8.4"
 


### PR DESCRIPTION
This PR updates the following dependencies
- rand: 0.8.3 -> 0.8.4
- rand_core: 0.6.2 -> 0.6.3
- rand_pcg: 0.3.0 -> 0.3.1
- **nalgebra: 0.25.3 -> 0.27.1**

No code change was necessary to make the crate compile and the tests pass.