### PR TITLE
Handle when the estimator can't find any solution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,12 @@ where
             }
         }
 
+        // Bail early when no hypothesis was found.
+        // This will cause execution to terminate.
+        if hypotheses.is_empty() {
+            return (hypotheses, 0.0);
+        }
+
         // Sort the hypotheses by their inliers.
         hypotheses.sort_unstable_by_key(|&(_, inliers)| Reverse(inliers));
 

--- a/tests/no_solutions.rs
+++ b/tests/no_solutions.rs
@@ -1,0 +1,38 @@
+use arrsac::Arrsac;
+use rand::SeedableRng;
+use rand_xoshiro::Xoshiro256PlusPlus;
+use sample_consensus::{Consensus, Estimator, Model};
+
+pub struct Unsolvable(f64);
+
+impl Model<i32> for Unsolvable {
+    fn residual(&self, _data: &i32) -> f64 {
+        return 0.01;
+    }
+}
+
+pub struct UnsolvableEstimator {}
+
+impl Estimator<i32> for UnsolvableEstimator {
+    type Model = Unsolvable;
+    type ModelIter = Option<Unsolvable>;
+    const MIN_SAMPLES: usize = 4;
+
+    fn estimate<I>(&self, _data: I) -> Self::ModelIter
+    where
+        I: Iterator<Item = i32> + Clone,
+    {
+        // Simulate all estimations failing.
+        None
+    }
+}
+
+/// It handles the case when the estimator fails to produce any solution from the given data
+#[test]
+pub fn no_valid_hypothesys() {
+    let rng = Xoshiro256PlusPlus::seed_from_u64(0);
+    let mut arrsac = Arrsac::new(3.0, rng.clone());
+    let estimator = UnsolvableEstimator {};
+    let result = arrsac.model(&estimator, 1..999);
+    assert!(result.is_none());
+}


### PR DESCRIPTION
Currently, when the estimator can't produce any hypothesis for the given dataset it panics: `thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0'`

This PR fixes the issue for me, but I'm not super familiar with ARRSAC. Let me know if this should be handled differently.  
Also, thanks a lot for the well documented code, i learned a lot by reading it! :heart: 