### PR TITLE
Update `rand` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 
 [dependencies]
 sample-consensus = "1.0.1"
-rand_core = "0.6.3"
+rand_core = "0.9"
 
 [dev-dependencies]
-rand = "0.8.4"
-rand_xoshiro = "0.6.0"
+rand = "0.9"
+rand_xoshiro = "0.7"
 
 [profile.dev]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ where
             }
         }
 
-        (inliers >= minimum_samples).then(|| inliers)
+        (inliers >= minimum_samples).then_some(inliers)
     }
 
     /// Determines the number of inliers a model has.

--- a/tests/lines.rs
+++ b/tests/lines.rs
@@ -91,7 +91,8 @@ fn lines() {
 
     for _ in 0..2000 {
         // Generate <a, b> and normalize.
-        let norm = Vector2::new(rng.random_range(-10.0..10.0), rng.random_range(-10.0..10.0)).normalize();
+        let norm =
+            Vector2::new(rng.random_range(-10.0..10.0), rng.random_range(-10.0..10.0)).normalize();
         // Get parallel ray.
         let ray = Vector2::new(norm.y, -norm.x);
         // Generate random c.

--- a/tests/lines.rs
+++ b/tests/lines.rs
@@ -1,6 +1,8 @@
 use arrsac::Arrsac;
-use rand::distributions::Uniform;
-use rand::{distributions::Distribution, Rng, SeedableRng};
+use rand::{
+    distr::{Distribution, Uniform},
+    Rng, SeedableRng,
+};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use sample_consensus::{Consensus, Estimator, Model};
 
@@ -89,18 +91,18 @@ fn lines() {
 
     for _ in 0..2000 {
         // Generate <a, b> and normalize.
-        let norm = Vector2::new(rng.gen_range(-10.0..10.0), rng.gen_range(-10.0..10.0)).normalize();
+        let norm = Vector2::new(rng.random_range(-10.0..10.0), rng.random_range(-10.0..10.0)).normalize();
         // Get parallel ray.
         let ray = Vector2::new(norm.y, -norm.x);
         // Generate random c.
-        let c = rng.gen_range(-10.0..10.0);
+        let c = rng.random_range(-10.0..10.0);
 
         // Generate random number of points between 50 and 1000.
-        let num = rng.gen_range(50..1000);
+        let num = rng.random_range(50..1000);
         // The points should be no more than 5.0 away from the line and be evenly distributed away from the line.
-        let residuals = Uniform::new(-5.0, 5.0);
+        let residuals = Uniform::new(-5.0, 5.0).unwrap();
         // The points must be generated along the line, but the distance should be bounded to make it more difficult.
-        let distances = Uniform::new(-50.0, 50.0);
+        let distances = Uniform::new(-50.0, 50.0).unwrap();
         // Generate the points.
         let points: Vec<Vector2<f64>> = (0..num)
             .map(|_| {

--- a/tests/no_solutions.rs
+++ b/tests/no_solutions.rs
@@ -3,7 +3,7 @@ use rand::SeedableRng;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use sample_consensus::{Consensus, Estimator, Model};
 
-pub struct Unsolvable(f64);
+pub struct Unsolvable(#[allow(dead_code)] f64);
 
 impl Model<i32> for Unsolvable {
     fn residual(&self, _data: &i32) -> f64 {


### PR DESCRIPTION
- update `rand_core`, `rand` to `0.9` and `rand_xoshiro` to `0.7`
- fix the new fallible constructor call for `Uniform::new` in tests
- make Clippy happy